### PR TITLE
Mejoras para trabajar aisladamente

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+Downloads/
+.venv

--- a/Facturas.py
+++ b/Facturas.py
@@ -84,7 +84,7 @@ def export(scrapped: list) -> None:
     
     filepath = Path(path+"/"+csv_file)
     filepath.parent.mkdir(parents = True, exist_ok = True)
-    df.to_csv(filepath, index = False)
+    df.to_excel(filepath, index = False)
     # writer = pd.ExcelWriter(path+"/"+csv_file,mode= "A")
     # df.to_excel(writer, sheet_name= "Cuadro")
     # writer.save()
@@ -98,7 +98,7 @@ if __name__ == "__main__":
     
     content=[]
     for filename in glob.glob(os.path.join(path,'*.xml')):
-        print( "\n----------", filename.split('\\')[1],"-----\n")
+        print( "\n----------", filename.split(os.sep)[1],"-----\n")
         print(filename)
         scrapped = parse_xml(path)
         content.append(scrapped)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # sri_xml
 Código para buscar información de facturas SRI a partir de su XML. 
 
-Pasos-
-1.- Crear una carpeta llamada "FACTURAS EJEMPLO".
-2.- Descargar todos los XML de todas las FACTURAS en la página del SRI.
-3.- Correr el programa y revisar el CSV en la carpeta.
+## Pasos
+1. Crear una carpeta llamada `FACTURAS EJEMPLO`.
+2. Descargar todos los XML de todas las FACTURAS en la página del SRI.
+5. Instalar con pip los requerimientos de `requirements.txt`.
+4. Correr el programa y revisar el CSV en la carpeta.
 
-pd: Puede que requiera installar ciertas cosas
+> pd: Puede que requiera installar ciertas cosas

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+beautifulsoup4==4.11.2
+pandas==1.5.3
+lxml==4.9.2
+openpyxl==3.1.1


### PR DESCRIPTION
- Agregar archivo de requirements.txt para cuando se trabaje en otra computadora solo se ejecute `pip install -r requirements.txt`.
- Actualizar el README con sintaxis Markdown para que se pueda leer mejor.
- Cambiar el separador de ruta de `\\` al que retorne Python independiente del sistema operativo.
- Cambiar la funcion a que ahora exporte con Excel.